### PR TITLE
Added docker & docker-compose to the project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ split_files/
 
 # Outputs.
 results_*/
+
+images/

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,21 +3,23 @@ FROM pytorch/pytorch:2.5.1-cuda11.8-cudnn9-devel
 WORKDIR /workspace
 
 RUN apt-get update && \
-    apt-get install wget -y && \
-    apt-get install git -y
+    apt-get install -y wget \
+    git libnvidia-egl-wayland1 \
+    xvfb mesa-utils libgl1-mesa-glx \
+    libgl1-mesa-dri libglib2.0-0
 
-# Install Miniconda
+# Install Miniforge
 RUN wget \
-    https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh \
+    https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh \
     && mkdir /root/.conda \
-    && bash Miniconda3-latest-Linux-x86_64.sh -b \
-    && rm -f Miniconda3-latest-Linux-x86_64.sh
+    && bash Miniforge3-Linux-x86_64.sh -b \
+    && rm -f Miniforge3-Linux-x86_64.sh
 
 RUN git clone https://github.com/nianticlabs/acezero --recursive
 
 RUN conda install ipykernel
 
-#Create ace0 env
+# Create ace0 env
 RUN cd acezero && \
     conda env create -f environment.yml
 
@@ -29,30 +31,19 @@ RUN echo "source activate ace0" > ~/.bashrc && \
 RUN cd acezero/dsacstar && \
     conda run -n ace0 python setup.py install
 
-#Install ace0 deps
-RUN apt-get install -y libnvidia-egl-wayland1
-RUN apt-get install -y xvfb mesa-utils
-RUN apt-get install -y libgl1-mesa-glx libgl1-mesa-dri
+# Set up Xvfb
 ENV DISPLAY=:99
 RUN Xvfb :99 -screen 0 1024x768x24 & export DISPLAY=:99
 
-# Install nerfstudio
-RUN conda create --name nerfstudio -y python=3.8
-
-RUN conda run -n nerfstudio pip install --upgrade pip
-
-RUN conda run -n nerfstudio pip install torch==2.1.2+cu118 torchvision==0.16.2+cu118 --extra-index-url https://download.pytorch.org/whl/cu118
-
-RUN conda run -n nerfstudio conda install -c "nvidia/label/cuda-11.8.0" cuda-toolkit
-
 ENV TCNN_CUDA_ARCHITECTURES="50;52;60;61;70;75;80;86"
 
-RUN conda run -n nerfstudio pip install ninja git+https://github.com/NVlabs/tiny-cuda-nn/#subdirectory=bindings/torch
-
-RUN conda run -n nerfstudio pip install nerfstudio
-
-RUN apt-get install -y libglib2.0-0
-
-RUN conda run -n nerfstudio ns-install-cli
+# Install nerfstudio
+RUN conda create --name nerfstudio -y python=3.8 && \
+    conda run -n nerfstudio pip install --upgrade pip && \
+    conda run -n nerfstudio pip install torch==2.1.2+cu118 torchvision==0.16.2+cu118 --extra-index-url https://download.pytorch.org/whl/cu118 && \
+    conda run -n nerfstudio conda install -c "nvidia/label/cuda-11.8.0" cuda-toolkit && \
+    conda run -n nerfstudio pip install ninja git+https://github.com/NVlabs/tiny-cuda-nn/#subdirectory=bindings/torch && \
+    conda run -n nerfstudio pip install nerfstudio && \
+    conda run -n nerfstudio ns-install-cli
 
 WORKDIR /workspace/acezero

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,58 @@
+FROM pytorch/pytorch:2.5.1-cuda11.8-cudnn9-devel
+
+WORKDIR /workspace
+
+RUN apt-get update && \
+    apt-get install wget -y && \
+    apt-get install git -y
+
+# Install Miniconda
+RUN wget \
+    https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh \
+    && mkdir /root/.conda \
+    && bash Miniconda3-latest-Linux-x86_64.sh -b \
+    && rm -f Miniconda3-latest-Linux-x86_64.sh
+
+RUN git clone https://github.com/nianticlabs/acezero --recursive
+
+RUN conda install ipykernel
+
+#Create ace0 env
+RUN cd acezero && \
+    conda env create -f environment.yml
+
+RUN echo "source activate ace0" > ~/.bashrc && \
+    conda run -n ace0 pip install ipykernel && \
+    conda install -n ace0 -c conda-forge libstdcxx-ng && \
+    /opt/conda/envs/ace0/bin/python -m ipykernel install --user --name=ace0
+
+RUN cd acezero/dsacstar && \
+    conda run -n ace0 python setup.py install
+
+#Install ace0 deps
+RUN apt-get install -y libnvidia-egl-wayland1
+RUN apt-get install -y xvfb mesa-utils
+RUN apt-get install -y libgl1-mesa-glx libgl1-mesa-dri
+ENV DISPLAY=:99
+RUN Xvfb :99 -screen 0 1024x768x24 & export DISPLAY=:99
+
+# Install nerfstudio
+RUN conda create --name nerfstudio -y python=3.8
+
+RUN conda run -n nerfstudio pip install --upgrade pip
+
+RUN conda run -n nerfstudio pip install torch==2.1.2+cu118 torchvision==0.16.2+cu118 --extra-index-url https://download.pytorch.org/whl/cu118
+
+RUN conda run -n nerfstudio conda install -c "nvidia/label/cuda-11.8.0" cuda-toolkit
+
+ENV TCNN_CUDA_ARCHITECTURES="50;52;60;61;70;75;80;86"
+
+RUN conda run -n nerfstudio pip install ninja git+https://github.com/NVlabs/tiny-cuda-nn/#subdirectory=bindings/torch
+
+RUN conda run -n nerfstudio pip install nerfstudio
+
+RUN apt-get install -y libglib2.0-0
+
+RUN conda run -n nerfstudio ns-install-cli
+
+WORKDIR /workspace/acezero

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ You can then shell into the container with the following command:
 docker exec -it acezero /bin/bash
 ```
 
-From there you can follow the Gaussian Splatting tutorial described at the bottom of the README [here.](#frequently-asked-questions) Make sure to add your images to the volume definded in ```docker-compose.yml```
+From there you can follow the Gaussian Splatting tutorial described at the bottom of the README [here.](#frequently-asked-questions) Make sure to add your images to the volume defined in ```docker-compose.yml```
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,22 @@ See [this link](https://github.com/isl-org/ZoeDepth) for its license and details
 ACE0 uses that model to estimate the depth for the seed images.
 It can be replaced, please see the [FAQ](#frequently-asked-questions) section below for details.
 
+## Docker
+
+If you would prefer to run Ace0 in a docker container, you can start it with:
+
+```shell  
+docker-compose up -d 
+```
+
+You can then shell into the container with the following command: 
+
+```shell  
+docker exec -it acezero /bin/bash
+```
+
+From there you can follow the Gaussian Splatting tutorial described at the bottom of the README [here.](#frequently-asked-questions) Make sure to add your images to the volume definded in ```docker-compose.yml```
+
 ## Usage
 
 We explain how to run ACE0 to reconstruct images from scratch, with and without knowledge about the image intrinsics.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,9 +10,7 @@ services:
     tty: true
     stdin_open: true
     ports:
-      - "7771:7007"
-    volumes:
-      - ./images:/workspace/images
+      - "7007:7007"
     deploy:
       resources:
         reservations:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+version: "3.8"
+
+services:
+  acezero:
+    restart: always
+    container_name: acezero
+    build:
+      context: .
+      dockerfile: Dockerfile
+    tty: true
+    stdin_open: true
+    ports:
+      - "7771:7007"
+    volumes:
+      - ./images:/workspace/images
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: 'nvidia'
+              count: all
+              capabilities: [gpu]
+    extra_hosts:
+      - "host.docker.internal:host-gateway"


### PR DESCRIPTION
Added support for docker-compose. This docker container will enable users to run both acezero & nerfstudio, allowing the creation of gaussian splats from just a few commands. I haven't fully tested all of the features of acezero, but am aware that some functionality like `--render_visualization` doesn't work in the docker container. 

Only added two files, the `Dockerfile` & `docker-compose.yml` file, and updated two files, the `.gitignore` & `README`

Hoping this will make ace0 more accessible and easier to contribute on!

Also, this was tested on a RTX 3060 12GB card on a Ubuntu host machine. Was able to successfully train a gaussian splat from datasets of 6000 & even 10000 images, both of which matched roughly 70% of each dataset and the camera  calibration results were quite impressive based on the nerfstudio splat. I'm going to try this on a larger gpu so I can hopefully train the splat at a higher resolution, since my 3060 can only handle a downscale value of 6. 